### PR TITLE
Fix error message display to show short format in status lines

### DIFF
--- a/gh-pull-all.mjs
+++ b/gh-pull-all.mjs
@@ -167,7 +167,7 @@ class StatusDisplay {
     
     let displayMessage = repo.message
     if (repo.status === 'failed' && repo.errorNumber) {
-      displayMessage = `Error #${repo.errorNumber}: ${this.truncateMessage(repo.message, availableWidth - 10)}`
+      displayMessage = `Failed with error #${repo.errorNumber}`
     } else {
       displayMessage = this.truncateMessage(repo.message, availableWidth)
     }
@@ -269,7 +269,7 @@ class StatusDisplay {
       
       let displayMessage = repo.message
       if (repo.status === 'failed' && repo.errorNumber) {
-        displayMessage = `Error #${repo.errorNumber}: ${this.truncateMessage(repo.message, availableWidth - 10)}`
+        displayMessage = `Failed with error #${repo.errorNumber}`
       } else {
         displayMessage = this.truncateMessage(repo.message, availableWidth)
       }

--- a/tests/test-error-handling.mjs
+++ b/tests/test-error-handling.mjs
@@ -55,8 +55,8 @@ async function testErrorHandling() {
     
     log('green', '✅ Error handling test completed')
     
-    // Check for error numbering in status messages
-    if (result.includes('Error #1:') || result.includes('Error #2:')) {
+    // Check for error numbering in status messages (Issue #11: now uses short format)
+    if (result.includes('Failed with error #1') || result.includes('Failed with error #2')) {
       log('green', '✅ Error numbering found in status messages')
     } else {
       throw new Error('Expected error numbering not found in status messages')

--- a/tests/test-error-message-display.mjs
+++ b/tests/test-error-message-display.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env bun
+
+// Test error message display - Issue #11
+// Download use-m dynamically
+const { use } = eval(await (await fetch('https://unpkg.com/use-m/use.js')).text());
+
+// Import modern npm libraries using use-m
+import { promises as fs } from 'fs'
+import path from 'path'
+const os = await import('os')
+const { execSync } = await import('child_process')
+
+// Colors for console output
+const colors = {
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+  magenta: '\x1b[35m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m'
+}
+
+const log = (color, message) => console.log(`${colors[color]}${message}${colors.reset}`)
+
+async function testErrorMessageDisplay() {
+  const testDir = path.join(os.tmpdir(), 'gh-pull-all-test-error-message-display')
+  
+  try {
+    log('blue', '🧪 Testing error message display (Issue #11)...')
+    
+    // Clean up any existing test directory
+    await fs.rm(testDir, {recursive: true, force: true})
+    await fs.mkdir(testDir, {recursive: true})
+    
+    // Create conflicting files to force errors
+    await fs.writeFile(path.join(testDir, 'Spoon-Knife'), 'conflicting file content')
+    await fs.writeFile(path.join(testDir, 'Hello-World'), 'another conflicting file')
+    
+    log('cyan', '🔧 Created conflicting files to trigger errors')
+    
+    // Run the script and expect some failures
+    let result
+    try {
+      result = execSync(`../gh-pull-all.mjs --user octocat --threads 2 --no-live-updates --dir ${testDir}`, {
+        encoding: 'utf8',
+        stdio: 'pipe'
+      })
+    } catch (execError) {
+      // The command might return non-zero exit code due to errors, but we still want the output
+      result = execError.stdout || ''
+    }
+    
+    log('green', '✅ Error message display test completed')
+    log('dim', 'Output preview:')
+    console.log(result.split('\n').slice(0, 20).join('\n'))
+    
+    // NEW TEST: Check that status messages show short error format
+    const statusLines = result.split('\n').filter(line => line.includes('❌'))
+    
+    for (const line of statusLines) {
+      if (line.includes('Error #')) {
+        // Should NOT contain the full error message in status display
+        // Should only show "Failed with error #X" or similar
+        if (line.includes('Your configuration specifies') || 
+            line.includes('already exists and is not an empty directory') ||
+            line.includes('from the remote, but no such ref was fetched')) {
+          throw new Error(`Status line contains full error message: ${line}`)
+        }
+        
+        // Should contain short error format like "Failed with error #1"
+        if (!line.includes('Failed with error #')) {
+          throw new Error(`Status line should contain 'Failed with error #X' format: ${line}`)
+        }
+      }
+    }
+    
+    log('green', '✅ Status lines use short error format')
+    
+    // Check that full error details are still in the errors section
+    if (result.includes('❌ Errors:')) {
+      log('green', '✅ Errors section found')
+      
+      // The errors section should contain the full details
+      const errorsSectionStart = result.indexOf('❌ Errors:')
+      const errorsSection = result.substring(errorsSectionStart)
+      
+      if (errorsSection.includes('destination path') || 
+          errorsSection.includes('already exists') ||
+          errorsSection.includes('Your configuration specifies')) {
+        log('green', '✅ Full error details found in errors section')
+      } else {
+        throw new Error('Expected full error details not found in errors section')
+      }
+    } else {
+      throw new Error('Expected errors section not found')
+    }
+    
+    log('green', '🎉 Error message display test passed!')
+    
+  } catch (error) {
+    log('red', `❌ Error message display test failed: ${error.message}`)
+    throw error
+  } finally {
+    // Clean up
+    try {
+      await fs.rm(testDir, {recursive: true, force: true})
+      log('cyan', '🧹 Cleaned up test directory')
+    } catch (cleanupError) {
+      log('yellow', `⚠️ Cleanup warning: ${cleanupError.message}`)
+    }
+  }
+}
+
+// Run the test
+testErrorMessageDisplay().catch(error => {
+  log('red', `💥 Test failed: ${error.message}`)
+  process.exit(1)
+})

--- a/tests/test-issue-11-integration.mjs
+++ b/tests/test-issue-11-integration.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env bun
+
+// Integration test for Issue #11 - Short error messages in status display
+// Download use-m dynamically
+const { use } = eval(await (await fetch('https://unpkg.com/use-m/use.js')).text());
+
+// Import modern npm libraries using use-m
+import { promises as fs } from 'fs'
+import path from 'path'
+const os = await import('os')
+const { execSync } = await import('child_process')
+
+// Colors for console output
+const colors = {
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+  magenta: '\x1b[35m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  reset: '\x1b[0m'
+}
+
+const log = (color, message) => console.log(`${colors[color]}${message}${colors.reset}`)
+
+async function testIssue11Integration() {
+  const testDir = path.join(os.tmpdir(), 'gh-pull-all-test-issue-11-integration')
+  
+  try {
+    log('blue', '🧪 Testing Issue #11 integration (short error messages)...')
+    
+    // Clean up any existing test directory
+    await fs.rm(testDir, {recursive: true, force: true})
+    await fs.mkdir(testDir, {recursive: true})
+    
+    // Create conflicting files to force errors
+    await fs.writeFile(path.join(testDir, 'Spoon-Knife'), 'conflicting file content')
+    await fs.writeFile(path.join(testDir, 'Hello-World'), 'another conflicting file')
+    
+    log('cyan', '🔧 Created conflicting files to trigger errors')
+    
+    // Test with different modes to ensure consistency
+    const testCases = [
+      { name: 'Multi-threaded with live updates', args: '--threads 2' },
+      { name: 'Multi-threaded without live updates', args: '--threads 2 --no-live-updates' },
+      { name: 'Single-threaded', args: '--single-thread' }
+    ]
+    
+    for (const testCase of testCases) {
+      log('cyan', `🔧 Testing: ${testCase.name}`)
+      
+      let result
+      try {
+        result = execSync(`../gh-pull-all.mjs --user octocat ${testCase.args} --dir ${testDir}`, {
+          encoding: 'utf8',
+          stdio: 'pipe'
+        })
+      } catch (execError) {
+        // The command might return non-zero exit code due to errors, but we still want the output
+        result = execError.stdout || ''
+      }
+      
+      // Validate the short error format in status display
+      const statusLines = result.split('\n').filter(line => line.includes('❌'))
+      let hasShortErrorFormat = false
+      
+      for (const line of statusLines) {
+        if (line.includes('Failed with error #')) {
+          hasShortErrorFormat = true
+          
+          // Ensure it doesn't contain full error details
+          if (line.includes('destination path') || 
+              line.includes('already exists and is not an empty directory') ||
+              line.includes('from the remote, but no such ref was fetched')) {
+            throw new Error(`Status line contains full error message in ${testCase.name}: ${line}`)
+          }
+        }
+      }
+      
+      if (!hasShortErrorFormat) {
+        throw new Error(`No short error format found in ${testCase.name}`)
+      }
+      
+      // Validate that full error details are in the errors section
+      if (!result.includes('❌ Errors:')) {
+        throw new Error(`Errors section missing in ${testCase.name}`)
+      }
+      
+      const errorsSectionStart = result.indexOf('❌ Errors:')
+      const errorsSection = result.substring(errorsSectionStart)
+      
+      if (!errorsSection.includes('destination path') && 
+          !errorsSection.includes('already exists')) {
+        throw new Error(`Full error details missing from errors section in ${testCase.name}`)
+      }
+      
+      log('green', `✅ ${testCase.name} passed`)
+    }
+    
+    // Test that successful operations still work normally
+    log('cyan', '🔧 Testing successful operations still display correctly')
+    
+    const cleanTestDir = path.join(os.tmpdir(), 'gh-pull-all-test-issue-11-clean')
+    await fs.rm(cleanTestDir, {recursive: true, force: true})
+    await fs.mkdir(cleanTestDir, {recursive: true})
+    
+    let successResult
+    try {
+      successResult = execSync(`../gh-pull-all.mjs --user octocat --threads 1 --dir ${cleanTestDir}`, {
+        encoding: 'utf8',
+        stdio: 'pipe',
+        timeout: 30000 // 30 second timeout for success case
+      })
+    } catch (execError) {
+      successResult = execError.stdout || ''
+    }
+    
+    // Should have successful clones without error messages
+    const successLines = successResult.split('\n').filter(line => line.includes('✅'))
+    
+    if (successLines.length === 0) {
+      throw new Error('No successful operations found in clean test')
+    }
+    
+    // Should not contain "Failed with error" in success cases
+    if (successResult.includes('Failed with error #')) {
+      throw new Error('Success case should not contain error messages')
+    }
+    
+    log('green', '✅ Successful operations display correctly')
+    
+    // Clean up clean directory
+    await fs.rm(cleanTestDir, {recursive: true, force: true})
+    
+    log('green', '🎉 Issue #11 integration test passed!')
+    
+  } catch (error) {
+    log('red', `❌ Issue #11 integration test failed: ${error.message}`)
+    throw error
+  } finally {
+    // Clean up
+    try {
+      await fs.rm(testDir, {recursive: true, force: true})
+      log('cyan', '🧹 Cleaned up test directory')
+    } catch (cleanupError) {
+      log('yellow', `⚠️ Cleanup warning: ${cleanupError.message}`)
+    }
+  }
+}
+
+// Run the test
+testIssue11Integration().catch(error => {
+  log('red', `💥 Test failed: ${error.message}`)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- Changes repository status display from "Error #1: <full message>" to "Failed with error #1"
- Full error details remain available in the errors section at the end of execution
- Improves readability and reduces clutter in status display during operation
- Maintains all existing functionality while addressing the UX issue

## Key Changes
- **Status display improvement**: Short error format ("Failed with error #1") instead of truncated full messages
- **Preserves detailed error reporting**: Full error messages still available in the errors section
- **Comprehensive test coverage**: Tests for all execution modes (single-thread, multi-thread with/without live updates)
- **Backwards compatibility**: No breaking changes to existing functionality

## Before
```
❌ repository                             5.9s Error #1: Your configuration specifies to merge with the ref 'refs/heads/feature-123423'...
```

## After
```
❌ repository                             5.9s Failed with error #1
```

Full error details remain available in the errors section:
```
❌ Errors:
────────────────────────────────────────────────────────────────────────────────
# 1 repository: Your configuration specifies to merge with the ref 'refs/heads/feature-123423' from the remote, but no such ref was fetched.
```

## Test Coverage
- **Unit tests**: Verify error message format in status display
- **Integration tests**: Test all execution modes (single-thread, multi-thread with/without live updates)
- **Regression tests**: Ensure existing error handling functionality remains intact
- **Edge case handling**: Verify successful operations are unaffected

## Implementation Details
- Modified `StatusDisplay.logStatusChange()` and `StatusDisplay.render()` methods
- Updated existing test expectations to match new format
- Added comprehensive test suite specifically for this issue
- Follows existing code patterns and conventions

## Test Plan
- [x] Unit tests for error message format validation
- [x] Integration tests for different execution modes
- [x] Verification that full error details remain in errors section
- [x] Confirmation that successful operations are unaffected
- [x] Updated existing tests to expect new format

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)